### PR TITLE
fix: run FlowPipeline on the pipeline's own device (ports #5)

### DIFF
--- a/src/phoenix/helpers/inference.py
+++ b/src/phoenix/helpers/inference.py
@@ -124,12 +124,12 @@ class FlowPipeline:
 
         pred_list, coords_list = [], []
         for batch in tqdm(dataloader, desc="Flow sampling"):
-            image, coords = batch[0].cuda(), batch[1]
+            image, coords = batch[0].to(device), batch[1]
             # nn.Module's __getattr__ stub can't see `vision_forward`, a method
             # specific to FlowTransformerModel; declaring `model: nn.Module`
             # keeps this pipeline decoupled from a specific model implementation.
             feats = self.model.vision_forward(image)  # type: ignore[operator]
-            noise = torch.randn(image.size(0), len(gene_list), 1).cuda()
+            noise = torch.randn(image.size(0), len(gene_list), 1, device=device)
 
             gex_pred = run_flow(
                 flow_model=self.model,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -43,3 +43,47 @@ def test_flow_pipeline_stores_mean_and_std(tiny_model):
     pipeline = FlowPipeline(model=tiny_model, stats=stats)
     np.testing.assert_array_equal(pipeline.mean, stats["mean"])
     np.testing.assert_array_equal(pipeline.std, stats["std"])
+
+
+@pytest.fixture
+def pipeline_model():
+    # `__call__` builds its noise with a trailing dim of 1, so the pipeline path needs
+    # d_genes=1 -- unlike `tiny_model`, which is shaped for run_flow's 4-wide x_0.
+    cfg = FlowTransformerConfig(
+        d_genes=1,
+        d_image=16,
+        d_model=16,
+        d_cross=16,
+        n_heads=2,
+        n_layers=1,
+        n_classes=0,
+        checkpoint=False,
+    )
+    return FlowTransformerModel(cfg, None).eval()
+
+
+def test_flow_pipeline_runs_on_cpu(pipeline_model):
+    """
+    FlowPipeline must run end-to-end without a GPU.
+
+    `vision_forward` is a pass-through when no vision model is set, so the loader can
+    yield already-extracted features directly.
+    """
+    from torch.utils.data import DataLoader, TensorDataset
+
+    torch.manual_seed(0)
+    n_samples, n_genes = 4, 3
+    feats = torch.randn(n_samples, 5, 16)
+    coords = torch.zeros(n_samples, 2)
+    # batch_size=1 would let the squeeze() inside __call__ collapse the batch dim
+    loader = DataLoader(TensorDataset(feats, coords), batch_size=2)
+
+    stats = {"mean": np.zeros(n_genes), "std": np.ones(n_genes)}
+    pipeline = FlowPipeline(model=pipeline_model, stats=stats, atol=1e-1, rtol=1e-1)
+    assert pipeline.device.type == "cpu"
+
+    gex_pred, coords_list = pipeline(["A", "B", "C"], loader)
+
+    assert gex_pred.shape == (n_samples, n_genes)
+    assert np.isfinite(gex_pred).all()
+    assert sum(len(c) for c in coords_list) == n_samples


### PR DESCRIPTION
## What

Inference crashed on CPU. `FlowPipeline.__call__` hardcoded `.cuda()` for both the batch images and the initial noise, so it raised `AssertionError: Torch not compiled with CUDA enabled` on any machine without a GPU.

```diff
- image, coords = batch[0].cuda(), batch[1]
+ image, coords = batch[0].to(device), batch[1]

- noise = torch.randn(image.size(0), len(gene_list), 1).cuda()
+ noise = torch.randn(image.size(0), len(gene_list), 1, device=device)
```

`device` is already derived from the model's own parameters (`self.device = next(self.model.parameters()).device`) a few lines above, and is already forwarded to `run_flow(device=device)`. These two lines were the only ones ignoring it.

## Credit — this ports #5

The fix is @philinscience's, from #5, and the commit retains their authorship.

That PR couldn't be merged directly: it predates the `src/` layout restructure, so it edits `phoenix/helpers/inference.py` — a path deleted by #11. Merging it produces a `modify/delete` conflict:

```
CONFLICT (modify/delete): phoenix/helpers/inference.py
  deleted in main, modified in pr/5
```

**The README half of #5 is deliberately not carried over.** #11 independently applied the same `github.` → `phoenix.` import fix; a test-merge confirms the resulting README is byte-identical to main's. Only the inference fix was still missing.

## Regression test

`tests/test_inference.py` covered `run_flow` and `FlowPipeline` construction but never called `__call__` — which is exactly why the hardcoded `.cuda()` survived the conformance pass. Adds `test_flow_pipeline_runs_on_cpu`, an end-to-end run over a small `DataLoader`.

Three details worth noting for review:

- It uses its own `d_genes=1` fixture. `__call__` builds noise with a trailing dim of **1**, unlike the existing `tiny_model` which is shaped for `run_flow`'s 4-wide `x_0`. This mirrors the notebook's real config.
- No stub vision model is needed — `FlowTransformerModel.vision_forward` is a pass-through when `vision_model is None`, so the loader yields already-extracted features.
- `batch_size=2` (not 1), because the `.squeeze()` inside `__call__` would otherwise collapse the batch dimension and make the shape assertion meaningless.

## Verified

- **The test genuinely reproduces the bug.** On the parent commit it fails with `AssertionError: Torch not compiled with CUDA enabled`; with the fix it passes.
- Full suite: **21 passed, 7 skipped** (up from 20 passed / 7 skipped — the one addition is this test, no regressions).
- `grep -rn "\.cuda()" src/` — no occurrences remain in `helpers/`, `datasets/`, or `trainers/`. The 18 remaining hits are all inside `if __name__ == "__main__"` demo blocks (`flow_simple.py:958`, `mlp_mixer_ae.py:514`, `flow_llama3.py:876`), confirmed to start after each block's opening line.
- `ruff check` and `ruff format --check` clean.

Closes #5
