### PR TITLE
chore: add CODEOWNERS for the two core maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Both core maintainers are auto-requested as reviewers on every pull request.
+# This is routing only: the `main` ruleset does not set `require_code_owner_review`,
+# so a CODEOWNERS approval is not a separate merge requirement on top of the
+# single approving review it already asks for.
+* @rushin682 @manuel-tran


### PR DESCRIPTION
Auto-requests @rushin682 and @manuel-tran as reviewers on every pull request. This is routing only -- the `main review` ruleset does not set `require_code_owner_review`, so this adds no merge requirement on top of the single approving review it already asks for.